### PR TITLE
Modified Args to be a bit cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can specify different versions of [YSlow.js](http://mervine.net/yslowjs) usi
 
     :::js
     var yslow = new YSlow('http://example.com/path/foo',
-        [ '--arg', 'value' ]);
+        [ '--arg value' ]);
         // Supported:
         //   info     specify the information to display/log (basic|grade|stats|comps|all) [all],
         //   ruleset  specify the YSlow performance ruleset to be used (ydefault|yslow1|yblog) [ydefault],

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can specify different versions of [YSlow.js](http://mervine.net/yslowjs) usi
     // file: async.js
     var YSlow = require('lib/yslow');
     var yslow = new YSlow('http://mervine.net/projects/npms/yslowjs',
-        [ '--info', 'basic' ]);
+        [ '--info basic' ]);
     console.log('\nRunning (Async)....');
     yslow.run( function (error, result) {
         if (error) {
@@ -73,7 +73,7 @@ You can specify different versions of [YSlow.js](http://mervine.net/yslowjs) usi
     // file: sync.js
     var YSlow = require('lib/yslow');
     var yslow = new YSlow('http://mervine.net/projects/npms/yslowjs',
-        [ '--info', 'basic' ]);
+        [ '--info basic' ]);
     console.log('\nRunning (Sync)....');
     var results = yslow.runSync();
     console.log('=> overall:   ' + results.o);

--- a/lib/yslow.js
+++ b/lib/yslow.js
@@ -8,8 +8,9 @@ function YSlow(url, args) {
     }
 
     args = args || [];
-    args.push('--format');
-    args.push('json');
+    args.push('--format json');
+    
+    args = args.join(" ").split(" ");
 
     this.url = url || 'http://localhost';
 


### PR DESCRIPTION
By modifying the args object to use a join(" ").split(" ") it allows the user to specify the desired options as such:
["--arg value","--arg value"] instead of ["--arg","value","--arg","value"]
